### PR TITLE
Handle validation errors in response.

### DIFF
--- a/lib/waitlisted/models/base.rb
+++ b/lib/waitlisted/models/base.rb
@@ -23,13 +23,21 @@ module Waitlisted
       end
 
       def parse_response(resp)
-        self.new(JSON.parse(resp))
+        hash = JSON.parse(resp)
+        raise_error(hash['errors']) if hash['errors']
+        response = self.new(hash)
+        response
       end
 
       def api_base(route)
         "/api/v1#{route}"
       end
 
-    end  
+      def raise_error(errors)
+        errors.each do |field, message|
+          raise StandardError, [field, message].join(' ')
+        end
+      end
+    end
   end
 end

--- a/spec/api/reservations_spec.rb
+++ b/spec/api/reservations_spec.rb
@@ -13,6 +13,11 @@ describe Waitlisted::Reservation do
       end
       expect(@reservation.position).not_to be_nil
     end
+    it "should raise an exception of already reserved" do
+      VCR.use_cassette("already_reserved") do
+        expect{Waitlisted::Reservation.create({email: "test@test.com"})}.to raise_error(StandardError, /email has already been taken/)
+      end
+    end
     it "should pull an existing reservation" do
       VCR.use_cassette("reservation") do
         @reservation = Waitlisted::Reservation.show({email: "test@test.com"})

--- a/spec/fixtures/vcr_cassettes/already_reserved.yml
+++ b/spec/fixtures/vcr_cassettes/already_reserved.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://waitlisted.app.waitlisted.co/api/v1/reservation
+    body:
+      encoding: UTF-8
+      string: reservation%5Bemail%5D=test%40test.com
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"a8f60142c2d27ebbe277d79d63269e46"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - request_method=POST; path=/
+      X-Request-Id:
+      - fb8b2ae5-d4d9-422b-8845-38ec4b476357
+      X-Runtime:
+      - '0.054027'
+      X-Powered-By:
+      - Phusion Passenger 4.0.56
+      Date:
+      - Tue, 07 Jul 2015 04:58:40 GMT
+      Server:
+      - nginx/1.6.2 + Phusion Passenger 4.0.56
+    body:
+      encoding: UTF-8
+      string: '{"errors":{"email":["has already been taken"]}}'
+    http_version:
+  recorded_at: Tue, 07 Jul 2015 04:58:41 GMT
+recorded_with: VCR 3.9.3


### PR DESCRIPTION
I ran into some issues in testing because my email address was already in the list. A small patch to do the smallest thing possible to alert me to what was going on because [this line(https://github.com/waitlisted/waitlisted-ruby/blob/master/lib/waitlisted/models/reservation.rb#L16) was assuming a reservation is always returned. A few things to consider before merging:

* Might be worth not returning `StandardError`. Maybe a dedicated error type for each? I'll need some input on what the expected error responses can be if that's preferred.
* I've not used `VCR` in years. I've no idea if this is the right way to simulate the error response.