### PR TITLE
Allow configuration to be auto-set from env var.

### DIFF
--- a/lib/waitlisted/configuration/base.rb
+++ b/lib/waitlisted/configuration/base.rb
@@ -1,7 +1,11 @@
 module Waitlisted
   module Configuration
     module Base
-      @@configuration = OpenStruct.new
+      if ENV['WAITLISTED_DOMAIN']
+        @@configuration = OpenStruct.new(url: "https://#{ENV['WAITLISTED_DOMAIN']}")
+      else
+        @@configuration = OpenStruct.new
+      end
       def configure(&block)
         yield configuration
       end


### PR DESCRIPTION
I'm trying to avoid the extra lifting of calling the `configure` block unless it's really required. So if I can infer from the environment variables on the system (following the 12factor approach to managing config) I'll set it automatically. 

* I went with `WAITLISTED_DOMAIN` instead of the full URL so that it could be used interchangeably in the javascript client too.
* Not tests :cry:. Given the way it set as a class variable it wasn't obvious how to test it without having tests impact each other. Made the decision that the effort to work around that wasn't worth it given the scope of the change.

Feedback welcome :)